### PR TITLE
Voter email-block status API, voters filter & branded emails

### DIFF
--- a/app/Http/Controllers/VoterListApiController.php
+++ b/app/Http/Controllers/VoterListApiController.php
@@ -75,6 +75,8 @@ class VoterListApiController extends Controller
             'string|in:id,email,title,phone|required_with:sort_direction',
             'sort_direction' =>
             'in:desc,asc|required_with:sort_by',
+            'filter' =>
+            'string|in:all,verified,unverified,bounced',
         ];
 
         if ($errors = $this->findErrors($params, $settings)) {
@@ -82,6 +84,18 @@ class VoterListApiController extends Controller
         }
 
         $query = $voterlist->voters();
+
+        switch ($params['filter'] ?? 'all') {
+            case 'verified':
+                $query->whereNotNull('voters.email_verified');
+                break;
+            case 'unverified':
+                $query->whereNull('voters.email_verified');
+                break;
+            case 'bounced':
+                $query->where('voters.email_blocked', true);
+                break;
+        }
 
         if (!empty($params['sort_by'])) {
             $query->orderBy(

--- a/app/Http/Resources/SentMessageBasic.php
+++ b/app/Http/Resources/SentMessageBasic.php
@@ -27,7 +27,8 @@ class SentMessageBasic extends JsonResource
             'successful'     => $this->successful,
             'status'         => $this->status,
             'status_msg'     => $this->status_msg,
-            'isVerification' => (bool) $this->verification_id
+            'isVerification' => (bool) $this->verification_id,
+            'created_at'     => $this->created_at,
         ];
     }
 }

--- a/app/Http/Resources/VoterBasic.php
+++ b/app/Http/Resources/VoterBasic.php
@@ -24,6 +24,8 @@ class VoterBasic extends JsonResource
             'title'          => $this->title,
             'email'          => $this->email,
             'email_verified' => $this->email_verified,
+            'email_blocked'  => (bool) $this->email_blocked,
+            'blocked_reason' => $this->blockedReason(),
             'phone'          => $this->phone,
             'phone_verified' => $this->phone_verified,
             'created_at'     => $this->created_at,

--- a/app/Http/Resources/VoterFull.php
+++ b/app/Http/Resources/VoterFull.php
@@ -24,6 +24,8 @@ class VoterFull extends JsonResource
             'title'          => $this->title,
             'email'          => $this->email,
             'email_verified' => $this->email_verified,
+            'email_blocked'  => (bool) $this->email_blocked,
+            'blocked_reason' => $this->blockedReason(),
             'phone'          => $this->phone,
             'phone_verified' => $this->phone_verified,
             'created_at'     => $this->created_at,

--- a/app/Http/Resources/VoterListFull.php
+++ b/app/Http/Resources/VoterListFull.php
@@ -31,6 +31,7 @@ class VoterListFull extends JsonResource
             'stats' => [
                 'voters'                => count($this->voters),
                 'voters_email_verified' => $this->voters->whereNotNull('email_verified')->count(),
+                'voters_blocked'        => $this->voters->where('email_blocked', true)->count(),
                 'sentMessages'          => count($this->sentMessages),
             ]
         ];

--- a/app/Models/Voter.php
+++ b/app/Models/Voter.php
@@ -130,4 +130,20 @@ class Voter extends Model
     {
         return $query->whereNotNull('phone_verified');
     }
+
+    /**
+     * Why this address is blocked, derived from the most recent hard delivery failure:
+     * 'bounce' (permanent bounce) or 'complaint' (marked as spam). Null when not blocked.
+     */
+    public function blockedReason(): ?string
+    {
+        if (! $this->email_blocked) {
+            return null;
+        }
+
+        return $this->sentMessages
+            ->whereIn('status', [SentMessage::STATUS_BOUNCE, SentMessage::STATUS_COMPLAINT])
+            ->sortByDesc('created_at')
+            ->first()?->status;
+    }
 }

--- a/resources/views/vendor/mail/html/header.blade.php
+++ b/resources/views/vendor/mail/html/header.blade.php
@@ -1,10 +1,10 @@
 <tr>
     <td class="header">
-        <a href="https://eglasovanje.si" style="display: inline-block;">
+        <a href="https://eglasovanje.si" style="display:inline-block;font-family:'Poppins',Helvetica,Arial,sans-serif;font-size:26px;font-weight:700;letter-spacing:-.02em;text-decoration:none;color:#11161a;">
             @if (!empty($personalization) && $personalization->photo_url)
                 <img src="{{ $personalization->photo_url }}" alt="Logo" width="auto" style="height: 75px">
             @else
-                eGlasovanje
+                <span style="color:#34b6df;">e</span>Glasovanje
             @endif
         </a>
     </td>

--- a/resources/views/vendor/mail/html/themes/default.css
+++ b/resources/views/vendor/mail/html/themes/default.css
@@ -11,7 +11,7 @@ body *:not(html):not(style):not(br):not(tr):not(code) {
 body {
     -webkit-text-size-adjust: none;
     background-color: #ffffff;
-    color: #718096;
+    color: #52525b;
     height: 100%;
     line-height: 1.4;
     margin: 0;
@@ -24,11 +24,11 @@ ul,
 ol,
 blockquote {
     line-height: 1.4;
-    text-align: left;
+    text-align: start;
 }
 
 a {
-    color: #3869d4;
+    color: #1b8fb8;
 }
 
 a img {
@@ -38,18 +38,18 @@ a img {
 /* Typography */
 
 h1 {
-    color: #3d4852;
+    color: #18181b;
     font-size: 18px;
     font-weight: bold;
     margin-top: 0;
-    text-align: left;
+    text-align: start;
 }
 
 h2 {
     font-size: 16px;
     font-weight: bold;
     margin-top: 0;
-    text-align: left;
+    text-align: start;
 }
 
 h3 {
@@ -80,7 +80,7 @@ img {
     -premailer-cellpadding: 0;
     -premailer-cellspacing: 0;
     -premailer-width: 100%;
-    background-color: #edf2f7;
+    background-color: #fafafa;
     margin: 0;
     padding: 0;
     width: 100%;
@@ -103,7 +103,7 @@ img {
 }
 
 .header a {
-    color: #3d4852;
+    color: #18181b;
     font-size: 19px;
     font-weight: bold;
     text-decoration: none;
@@ -113,6 +113,9 @@ img {
 
 .logo {
     height: 75px;
+    margin-top: 15px;
+    margin-bottom: 10px;
+    max-height: 75px;
     width: 75px;
 }
 
@@ -122,9 +125,9 @@ img {
     -premailer-cellpadding: 0;
     -premailer-cellspacing: 0;
     -premailer-width: 100%;
-    background-color: #edf2f7;
-    border-bottom: 1px solid #edf2f7;
-    border-top: 1px solid #edf2f7;
+    background-color: #fafafa;
+    border-bottom: 1px solid #fafafa;
+    border-top: 1px solid #fafafa;
     margin: 0;
     padding: 0;
     width: 100%;
@@ -135,19 +138,23 @@ img {
     -premailer-cellspacing: 0;
     -premailer-width: 570px;
     background-color: #ffffff;
-    border-color: #e8e5ef;
-    border-radius: 2px;
+    border-color: #e4e4e7;
+    border-radius: 4px;
     border-width: 1px;
-    box-shadow: 0 2px 0 rgba(0, 0, 150, 0.025), 2px 4px 0 rgba(0, 0, 150, 0.015);
+    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1);
     margin: 0 auto;
     padding: 0;
     width: 570px;
 }
 
+.inner-body a {
+    word-break: break-all;
+}
+
 /* Subcopy */
 
 .subcopy {
-    border-top: 1px solid #e8e5ef;
+    border-top: 1px solid #e4e4e7;
     margin-top: 25px;
     padding-top: 25px;
 }
@@ -169,13 +176,13 @@ img {
 }
 
 .footer p {
-    color: #b0adc5;
+    color: #a1a1aa;
     font-size: 12px;
     text-align: center;
 }
 
 .footer a {
-    color: #b0adc5;
+    color: #a1a1aa;
     text-decoration: underline;
 }
 
@@ -190,13 +197,13 @@ img {
 }
 
 .table th {
-    border-bottom: 1px solid #edeff2;
+    border-bottom: 1px solid #e4e4e7;
     margin: 0;
     padding-bottom: 8px;
 }
 
 .table td {
-    color: #74787e;
+    color: #52525b;
     font-size: 15px;
     line-height: 18px;
     margin: 0;
@@ -218,6 +225,7 @@ img {
     padding: 0;
     text-align: center;
     width: 100%;
+    float: unset;
 }
 
 .button {
@@ -231,46 +239,47 @@ img {
 
 .button-blue,
 .button-primary {
-    background-color: #2d3748;
-    border-bottom: 8px solid #2d3748;
-    border-left: 18px solid #2d3748;
-    border-right: 18px solid #2d3748;
-    border-top: 8px solid #2d3748;
+    background-color: #34b6df;
+    border-bottom: 8px solid #34b6df;
+    border-left: 18px solid #34b6df;
+    border-right: 18px solid #34b6df;
+    border-top: 8px solid #34b6df;
+    color: #053040;
 }
 
 .button-green,
 .button-success {
-    background-color: #48bb78;
-    border-bottom: 8px solid #48bb78;
-    border-left: 18px solid #48bb78;
-    border-right: 18px solid #48bb78;
-    border-top: 8px solid #48bb78;
+    background-color: #16a34a;
+    border-bottom: 8px solid #16a34a;
+    border-left: 18px solid #16a34a;
+    border-right: 18px solid #16a34a;
+    border-top: 8px solid #16a34a;
 }
 
 .button-red,
 .button-error {
-    background-color: #e53e3e;
-    border-bottom: 8px solid #e53e3e;
-    border-left: 18px solid #e53e3e;
-    border-right: 18px solid #e53e3e;
-    border-top: 8px solid #e53e3e;
+    background-color: #dc2626;
+    border-bottom: 8px solid #dc2626;
+    border-left: 18px solid #dc2626;
+    border-right: 18px solid #dc2626;
+    border-top: 8px solid #dc2626;
 }
 
 /* Panels */
 
 .panel {
-    border-left: #2d3748 solid 4px;
+    border-left: #18181b solid 4px;
     margin: 21px 0;
 }
 
 .panel-content {
-    background-color: #edf2f7;
-    color: #718096;
+    background-color: #fafafa;
+    color: #52525b;
     padding: 16px;
 }
 
 .panel-content p {
-    color: #718096;
+    color: #52525b;
 }
 
 .panel-item {


### PR DESCRIPTION
Supports the web_app voter-list/verification UX work (SiVoteApp `feature/dashboard-account-home`).

## Changes
- **Expose voter email-block status** in the API: `VoterBasic`/`VoterFull` now return `email_blocked` (bool) and `blocked_reason` (`bounce`/`complaint`/null, derived from the voter's most recent hard delivery failure via a new `Voter::blockedReason()` — reuses the already-loaded `sentMessages`, no new queries). `VoterListFull.stats` gains `voters_blocked`.
- **Status filter on the paginated voters endpoint**: `GET /api/voterlist/{id}/voters?filter=all|verified|unverified|bounced`, so consumers can page through just the bounced/unverified voters instead of filtering one loaded page client-side.
- **`created_at` on `SentMessageBasic`** so consumers can show when each message was sent (e.g. group a verification's messages by batch into a send history).
- **Branded markdown emails**: the published `vendor/mail` theme was still stock Laravel (slate `#2d3748` button, generic links). Aligned to the eGlasovanje brand (button `#34b6df`/text `#053040`, links `#1b8fb8`, brand neutrals) and a branded header wordmark, keeping the org personalization-logo branch. Affects all sender emails (verification, ballot invite/result, session invite, test).

All additive; no behaviour change to existing fields. PHPStan level 8 clean, full suite green (75 tests).